### PR TITLE
Add missing ConfigSchema to ADS1115VoltageInput

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,9 +13,9 @@ default_envs =
 framework = arduino
 lib_ldf_mode = deep
 monitor_speed = 115200
+upload_speed = 2000000
 lib_deps =
-  ; Use the latest development version of SensESP
-  https://github.com/SignalK/SensESP.git#dev-3
+  SignalK/SensESP @ >=3.0.0-beta.5,<4.0.0-alpha.1
   ; Add any additional dependencies here
   adafruit/Adafruit SSD1306 @ ^2.5.1
   ttlappalainen/NMEA2000-library@^4.17.2
@@ -36,10 +36,14 @@ extends = espressif32_base
 board = esp32dev
 build_flags =
   -D LED_BUILTIN=2
-  ; Uncomment the following to disable debug output altogether
-  ;-D DEBUG_DISABLED
-  ; Uncomment the following to enable the remote debug telnet interface on port 23
-  ;-D REMOTE_DEBUG
+  -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
+  -D TAG='"Arduino"'
+  -D USE_ESP_IDF_LOG
+  ; Comment out this line to disable NMEA 2000 output.
+  -D ENABLE_NMEA2000_OUTPUT
+  ; Comment out this line to disable Signal K support. At the moment, disabling
+  ; Signal K support also disables all WiFi functionality.
+  -D ENABLE_SIGNALK
 
 ;; Uncomment and change these if PlatformIO can't auto-detect the ports
 ;upload_port = /dev/tty.SLAB_USBtoUART

--- a/src/halmet_analog.h
+++ b/src/halmet_analog.h
@@ -43,18 +43,6 @@ class ADS1115VoltageInput : public sensesp::FloatSensor {
     root["calibration_value"] = calibration_factor_;
   };
 
-  String get_config_schema() {
-    const char SCHEMA[] = R"###({
-      "type": "object",
-      "properties": {
-          "read_interval": { "title": "Read interval", "type": "number", "description": "Number of milliseconds between each reading" },
-          "calibration_factor": { "title": "Calibration factor", "type": "number", "description": "Scale factor to fix the input calibration" }
-      }
-    })###";
-
-    return SCHEMA;
-  }
-
   bool set_configuration(const JsonObject& config) {
     String expected[] = {"read_interval"};
     if (!config["read_interval"].is<int>()) {
@@ -86,6 +74,23 @@ class ADS1115VoltageInput : public sensesp::FloatSensor {
   unsigned int read_interval_;
   float calibration_factor_;
 };
+
+inline const String ConfigSchema(const ADS1115VoltageInput& obj) {
+  const char SCHEMA[] = R"###({
+      "type": "object",
+      "properties": {
+          "read_interval": { "title": "Read interval", "type": "number", "description": "Number of milliseconds between each reading" },
+          "calibration_factor": { "title": "Calibration factor", "type": "number", "description": "Scale factor to fix the input calibration" }
+      }
+    })###";
+
+  return SCHEMA;
+}
+
+inline const bool ConfigRequiresRestart(const ADS1115VoltageInput& obj) {
+  return true;
+}
+
 
 }  // namespace halmet
 


### PR DESCRIPTION
Having a ConfigSchema for all Saveables became a requirement in SensESP v3.0.0-beta.6 but I failed to update the example firmware. Fixed now.

The platformio.ini file was also left behind.

See also PR #7.