### PR TITLE
I2C regression workaround

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,10 @@ build_flags =
 
 [pioarduino]
 
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+# Required until these issues are resolved:
+# - https://github.com/espressif/arduino-esp32/issues/11228
+# - https://github.com/espressif/esp-idf/issues/15734
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip
 framework = arduino
 
 ; The library.json format doesn't support dependencies conditional on the

--- a/platformio.ini
+++ b/platformio.ini
@@ -74,7 +74,7 @@ framework = arduino
 
 lib_deps =
     ${env.lib_deps}
-    esp_websocket_client=https://components.espressif.com/api/downloads/?object_type=component&object_id=dbc87006-9a4b-45e6-a6ab-b286174cb413
+    esp_websocket_client=https://components.espressif.com/api/downloads/?object_type=component&object_id=b072eea5-4e65-4ced-94c3-d6f24207062d
 
 build_flags =
     ${env.build_flags}


### PR DESCRIPTION
Version 3.2.0 of Arduino-ESP32 has broken I2C functionality that remains unfixed in 3.3.0. This PR reverts the HALMET example codebase back to 3.1.3.

The project is also simplified - conditional compilation of Signal K and NMEA 2000 has been removed because the #define pragmas were accidentally removed in an earlier change, and the codebase is easier to read without the conditional sections.