### PR TITLE
feat: enable SSL/TLS support for Signal K connections

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -78,6 +78,8 @@ lib_deps =
 
 build_flags =
     ${env.build_flags}
+    ; Enable SSL/TLS support for Signal K server connections
+    -D SENSESP_SSL_SUPPORT=1
 
 [espidf]
 
@@ -100,6 +102,8 @@ lib_deps =
 
 build_flags =
     ${env.build_flags}
+    ; Enable SSL/TLS support for Signal K server connections
+    -D SENSESP_SSL_SUPPORT=1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Board configurations follow


### PR DESCRIPTION
## Summary

Add `SENSESP_SSL_SUPPORT=1` build flag to pioarduino and espidf platform configurations.

This enables SSL/TLS with TOFU (Trust On First Use) certificate verification when connecting to Signal K servers with self-signed certificates.

## Test plan

- [ ] Build with pioarduino platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)